### PR TITLE
Adding the duration between entry and exit in the exited geofence event

### DIFF
--- a/Tests/WoosmapGeofencingTests/DurationLogTest.swift
+++ b/Tests/WoosmapGeofencingTests/DurationLogTest.swift
@@ -1,0 +1,90 @@
+//
+//  DurationLogTest.swift
+//  WoosmapGeofencingCoreTests
+//
+//  Created by WGS on 12/08/22.
+//  Copyright © 2022 Web Geo Services. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+@testable import WoosmapGeofencingCore
+
+class DurationLogTest: XCTestCase {
+    let dateFormatter = DateFormatter()
+    
+    override func setUp() {
+        super.setUp()
+        let documentDirectory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
+                                                                     appropriateFor: nil, create: false)
+        let url = documentDirectory!.appendingPathComponent("region\(Date.timeIntervalBetween1970AndReferenceDate).realm")
+        Realm.Configuration.defaultConfiguration.fileURL = url
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX") // set locale to reliable US_POSIX
+        dateFormatter.dateFormat = "yyyy-MM-dd' 'HH:mm:ssZ"
+    }
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testEntryEvent() throws {
+        DurationLogs.addEntryLog(identifier: "test1")
+        let count = DurationLogs.getAll().count
+        XCTAssert(count > 0)
+        DurationLogs.deleteAll()
+    }
+    
+    func testExitEvent() throws {
+        let exp = expectation(description: "Test after 5 seconds")
+        DurationLogs.addEntryLog(identifier: "test1")
+        let result = XCTWaiter.wait(for: [exp], timeout: 5.0)
+        if result == XCTWaiter.Result.timedOut {
+            let duration = DurationLogs.addExitLog(identifier: "test1")
+            print("time spend \(duration)")
+            XCTAssert(duration > 5)
+         } else {
+             XCTFail("Delay interrupted")
+         }
+        DurationLogs.deleteAll()
+    }
+    func testExitEventWithoutEntryLog() throws {
+        let exp = expectation(description: "Test after 5 seconds")
+        let result = XCTWaiter.wait(for: [exp], timeout: 5.0)
+        if result == XCTWaiter.Result.timedOut {
+            let duration = DurationLogs.addExitLog(identifier: "testNotFound")
+            print("time spend \(duration)")
+            XCTAssert(duration == 0)
+         } else {
+             XCTFail("Delay interrupted")
+         }
+        DurationLogs.deleteAll()
+    }
+    
+    func testDuplicateEntryEvent() throws {
+        let exp = expectation(description: "Test after 5 seconds")
+        let expAgain = expectation(description: "Test after 5 seconds")
+        DurationLogs.addEntryLog(identifier: "test1")
+        let result = XCTWaiter.wait(for: [exp], timeout: 5.0)
+        if result == XCTWaiter.Result.timedOut {
+            //Duplicate ID
+            DurationLogs.addEntryLog(identifier: "test1")
+            let resultAgain = XCTWaiter.wait(for: [expAgain], timeout: 5.0)
+            if resultAgain == XCTWaiter.Result.timedOut {
+            let duration = DurationLogs.addExitLog(identifier: "test1")
+            XCTAssert(duration > 10)
+                let durationNew = DurationLogs.addExitLog(identifier: "test1")
+                XCTAssert(durationNew > 5)
+            }
+            else{
+                XCTFail("Delay interrupted")
+            }
+         } else {
+             XCTFail("Delay interrupted")
+         }
+        DurationLogs.deleteAll()
+    }
+}

--- a/Tests/WoosmapGeofencingTests/DurationLogTest.swift
+++ b/Tests/WoosmapGeofencingTests/DurationLogTest.swift
@@ -17,7 +17,7 @@ class DurationLogTest: XCTestCase {
         super.setUp()
         let documentDirectory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
                                                                      appropriateFor: nil, create: false)
-        let url = documentDirectory!.appendingPathComponent("region\(Date.timeIntervalBetween1970AndReferenceDate).realm")
+        let url = documentDirectory!.appendingPathComponent("durationlog\(Date.timeIntervalBetween1970AndReferenceDate).realm")
         Realm.Configuration.defaultConfiguration.fileURL = url
         dateFormatter.locale = Locale(identifier: "en_US_POSIX") // set locale to reliable US_POSIX
         dateFormatter.dateFormat = "yyyy-MM-dd' 'HH:mm:ssZ"

--- a/Tests/WoosmapGeofencingTests/DurationLogTest.swift
+++ b/Tests/WoosmapGeofencingTests/DurationLogTest.swift
@@ -29,13 +29,14 @@ class DurationLogTest: XCTestCase {
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+        DurationLogs.deleteAll()
     }
 
     func testEntryEvent() throws {
         DurationLogs.addEntryLog(identifier: "test1")
         let count = DurationLogs.getAll().count
         XCTAssert(count > 0)
-        DurationLogs.deleteAll()
+        
     }
     
     func testExitEvent() throws {
@@ -44,12 +45,11 @@ class DurationLogTest: XCTestCase {
         let result = XCTWaiter.wait(for: [exp], timeout: 5.0)
         if result == XCTWaiter.Result.timedOut {
             let duration = DurationLogs.addExitLog(identifier: "test1")
-            print("time spend \(duration)")
             XCTAssert(duration > 5)
          } else {
              XCTFail("Delay interrupted")
          }
-        DurationLogs.deleteAll()
+        
     }
     func testExitEventWithoutEntryLog() throws {
         let exp = expectation(description: "Test after 5 seconds")
@@ -61,7 +61,7 @@ class DurationLogTest: XCTestCase {
          } else {
              XCTFail("Delay interrupted")
          }
-        DurationLogs.deleteAll()
+        
     }
     
     func testDuplicateEntryEvent() throws {
@@ -85,6 +85,5 @@ class DurationLogTest: XCTestCase {
          } else {
              XCTFail("Delay interrupted")
          }
-        DurationLogs.deleteAll()
     }
 }

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5F5CD5EA28A6302C0074D7DD /* DurationLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */; };
 		5FB3E7A32872F2BE0035653E /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB3E7A22872F2BE0035653E /* LocationService.swift */; };
 		5FB3E7A52872F3170035653E /* LocationServiceCoreImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB3E7A42872F3170035653E /* LocationServiceCoreImpl.swift */; };
 		A24796FF2726DF700081AADC /* Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24796FE2726DF700081AADC /* Distance.swift */; };
@@ -60,6 +61,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationLogTest.swift; sourceTree = "<group>"; };
 		5FB3E7A22872F2BE0035653E /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		5FB3E7A42872F3170035653E /* LocationServiceCoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceCoreImpl.swift; sourceTree = "<group>"; };
 		A216FBA923E9CEA70003AAC8 /* WoosmapGeofencingCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WoosmapGeofencingCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -183,6 +185,7 @@
 				A262B9C524E29ADF00EB621F /* FIGMMCreatorTests.swift */,
 				A262B9C724E29ADF00EB621F /* Info.plist */,
 				A262B9C624E29ADF00EB621F /* ZoiQualifierTests.swift */,
+				5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */,
 			);
 			name = WoosmapGeofencingTests;
 			path = Tests/WoosmapGeofencingTests;
@@ -335,6 +338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A26E646125B98BDD00EDBA72 /* DelayDataDurationTests.swift in Sources */,
+				5F5CD5EA28A6302C0074D7DD /* DurationLogTest.swift in Sources */,
 				A262B9C824E29ADF00EB621F /* FIGMMCreatorTests.swift in Sources */,
 				A2DDC91B25C86B0C00C90486 /* DatabaseTests.swift in Sources */,
 				A262B9C924E29ADF00EB621F /* ZoiQualifierTests.swift in Sources */,


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->

# Description
By Adding the duration between entry and exit in the exited geofence event. It will provide helpful information about time spent in the geofence.
## Issue

closes #2


## What


## How
SDK Modified 
- To define new data structure(DurationLog) to save entry/exit event log, identifier, entryTime, exitTime
- At the time of new entry in the region object, we know that the user enters or exits that region.
- We calculate time difference at that time and save it in the spentTime object.
- Whenever geofence event fire it return the region object, now it has information about time spent by the user in the region 

## Related PRs
N/A

# Testing
## Automated tests
- [ ] Unit Tests cover the change
 

<!-- Notice: if one of the above boxes is not ticked, please explain why. -->

## Steps to test or reproduce
- Create new geofence region in SDK
- Change User location on simulator near to Geofence zone so `didEnterPOIRegion` event called. Check region.spentTime object, It Should be 0(zero)
- Wait for 30 seconds
- Move User location far away from Current Location
- Now `didExitPOIRegion` fires called. Check region.spentTime object, It Should be more then 30 seconds



# Deployment
## Strategy
- [ ] This is a standard deployment

<!-- Warning: if this box is not ticked, please detail the steps to deploy and TALK TO THE OPS TEAM! -->

## Migrations
<!-- Choose one -->
No.
