### PR TITLE
Added API headers on woosmap API

### DIFF
--- a/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
@@ -839,10 +839,13 @@ public class LocationServiceCoreImpl: NSObject,
     }
     
     public func woosApiCall(with url: URL, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) {
+        let bundle = Bundle(for: LocationServiceCoreImpl.self)
         var url = URLRequest(url: url)
+        
         url.addValue("geofence-sdk", forHTTPHeaderField: "X-SDK-Source")
         url.addValue("iOS", forHTTPHeaderField: "X-AK-SDK-Platform")
-        url.addValue("3.0.x", forHTTPHeaderField: "X-AK-SDK-Version")
+        
+        url.addValue(bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "3.0.0", forHTTPHeaderField: "X-AK-SDK-Version")
         url.addValue(Bundle.main.bundleIdentifier ?? "unknown", forHTTPHeaderField: "X-iOS-Identifier")
         url.addValue(WoosmapAPIKey, forHTTPHeaderField: "X-Api-Key")
         

--- a/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
@@ -7,7 +7,7 @@ import Foundation
 import CoreLocation
 
 /// Location service implementation
-open class LocationServiceCoreImpl: NSObject,
+public class LocationServiceCoreImpl: NSObject,
                                     LocationService,
                                     LocationServiceInternal,
                                     CLLocationManagerDelegate  {

--- a/Sources/WoosmapGeofencing/LocationService.swift
+++ b/Sources/WoosmapGeofencing/LocationService.swift
@@ -130,6 +130,8 @@ public protocol LocationService: NSObject {
     func locationManagerDidPauseLocationUpdates(_ manager: CLLocationManager)
     
     func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion)
+    
+    func woosApiCall(with url: URL,completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void)
 }
 
 public extension LocationService {

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = WebGeoServices.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = WebGeoServices.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

# Description
## Issue
Woosmap/geofencing-enterprise-ios-sdk#61

## What
Passing Product header from SDK to Woos API

## How
Update API headers with these values
   ```
  “X-iOS-Identifier”: [[NSBundle mainBundle] bundleIdentifier],
  “X-SDK-Source”: @“geofance-sdk”,
  “X-AK-SDK-Platform”: @“iOS”,
  “X-AK-SDK-Version”: "3.0.x",
  "X-Api-Key": private_key,
```

## Related PRs
N/A

# Testing
## Automated tests
- [x] Unit Tests cover the change
- [x] Smoke Tests cover the change  

Please run the sample application and Check the console for API parameters.

# Deployment
## Strategy
- [x] This is a standard deployment

<!-- Warning: if this box is not ticked, please detail the steps to deploy and TALK TO THE OPS TEAM! -->

## Migrations
<!-- Choose one -->
No.
