### PR TITLE
Deprecated serachAPIError and introduce searchAPIError

### DIFF
--- a/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
@@ -623,6 +623,7 @@ public class LocationServiceCoreImpl: NSObject,
                         }
                     }
                     delegate.serachAPIError(error: "Error Search API " + String(response.statusCode))
+                    delegate.searchAPIError(error: "Error Search API " + String(response.statusCode))
                     return
                 }
                 if let error = error {

--- a/Sources/WoosmapGeofencing/Monitor.swift
+++ b/Sources/WoosmapGeofencing/Monitor.swift
@@ -11,7 +11,19 @@ public protocol LocationServiceDelegate: AnyObject {
 /// Search Service callback
 public protocol SearchAPIDelegate: AnyObject {
     func searchAPIResponse(poi: POI)
+    @available(*, deprecated, renamed: "searchAPIError()")
     func serachAPIError(error: String)
+    func searchAPIError(error: String)
+}
+public extension SearchAPIDelegate{
+    //Mark as optional
+    func serachAPIError(error: String) {
+        
+    }
+    //Mark as optional
+    func searchAPIError(error: String){
+        
+    }
 }
 
 /// Distance API Callback

--- a/Sources/WoosmapGeofencing/Monitor.swift
+++ b/Sources/WoosmapGeofencing/Monitor.swift
@@ -11,7 +11,7 @@ public protocol LocationServiceDelegate: AnyObject {
 /// Search Service callback
 public protocol SearchAPIDelegate: AnyObject {
     func searchAPIResponse(poi: POI)
-    @available(*, deprecated, renamed: "searchAPIError()")
+    @available(*, deprecated, renamed: "searchAPIError(error:)")
     func serachAPIError(error: String)
     func searchAPIError(error: String)
 }


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
Woosmap/geofencing-enterprise-ios-sdk#90

## Describe your changes
SDK added a new method `searchAPIError` and marked the current method serachAPIError as deprecated due to a typo in the method name.

## How to test
Please test PR: https://github.com/Woosmap/geofencing-enterprise-ios-sdk/pull/91


