### PR TITLE
Reduce number Location request call while user is idle

### DIFF
--- a/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
@@ -281,10 +281,10 @@ public class LocationServiceCoreImpl: NSObject,
             }
         }
         
-        if let history = lastfatchLocation{
+        if let history = self.lastfatchLocation{
             let distanceupdated = history.distance(from: newLocation) // meter
             let timeskipped = newLocation.timestamp.seconds(from: history.timestamp) //Seconds
-            if(distanceupdated < 5 &&  timeskipped < 5){ //Small changes
+            if(distanceupdated < 5 &&  timeskipped < 10){ //Small changes
                 self.stopUpdatingLocation()
                 return
             }


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
Woosmap/geofencing-enterprise-ios-sdk#124

## Describe your changes
SDK looks for changes in small intervals and ignores it if the time spent by the user is less than 10 seconds.

## How to test
Run the example app in the enterprise SDK and check the location collected by the SDK with the timestamp. You will notice that the timestamp in two consecutive locations is more than 10 seconds apart.

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] ~My code passes the SonarCloud check and does not add new code smells~
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
Not required

### Libs/SDKs
Not required
