### PR TITLE
Return OpenNow status from opening_hour specification

### DIFF
--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -1,0 +1,202 @@
+//
+//  OpeningHoursChecker.swift
+//  WoosmapGeofencingCore
+//
+//  Created by Woosmap on 28/07/25.
+//  Copyright © 2025 Woosmap. All rights reserved.
+
+
+
+import Foundation
+struct OpeningHours: Codable {
+    var usual: [String: [OpeningPeriod]]
+    let special: [String: [OpeningPeriod]]
+    let temporaryClosure: [String]
+    let timezone: String
+
+    enum CodingKeys: String, CodingKey {
+        case usual, special, timezone
+        case temporaryClosure = "temporary_closure"
+    }
+    
+    static func openingHoursFrom(dictionary: [String: Any]) -> OpeningHours? {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            let decoder = JSONDecoder()
+            return try decoder.decode(OpeningHours.self, from: data)
+        } catch {
+            print("Failed to decode OpeningHoursData: \(error)")
+            return nil
+        }
+    }
+}
+
+struct OpeningPeriod: Codable {
+    let start: String?
+    let end: String?
+    let allDay: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case start, end
+        case allDay = "all-day"
+    }
+}
+
+struct WeeklyOpening: Codable {
+    let days: [String: DayOpening]
+    let timezone: String
+    enum CodingKeys: String, CodingKey {
+        case timezone
+    }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timezone = try container.decode(String.self, forKey: .timezone)
+
+        // decode all day keys ("1"..."7")
+        let dynamicContainer = try decoder.container(keyedBy: DynamicKey.self)
+        var tempDays: [String: DayOpening] = [:]
+        for key in dynamicContainer.allKeys {
+            if let intKey = Int(key.stringValue), (1...7).contains(intKey) {
+                let dayOpening = try dynamicContainer.decode(DayOpening.self, forKey: key)
+                tempDays[key.stringValue] = dayOpening
+            }
+        }
+        days = tempDays
+    }
+
+    struct DynamicKey: CodingKey {
+        var stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int? { return Int(stringValue) }
+        init?(intValue: Int) { self.stringValue = "\(intValue)" }
+    }
+    
+    static func weeklyOpeningFrom(dictionary: [String: Any]) -> WeeklyOpening? {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            let decoder = JSONDecoder()
+            return try decoder.decode(WeeklyOpening.self, from: data)
+        } catch {
+            print("Failed to decode WeeklyOpening: \(error)")
+            return nil
+        }
+    }
+}
+
+struct DayOpening: Codable {
+    let hours: [OpeningPeriod]
+    let isSpecial: Bool
+}
+
+
+struct OpeningStatus {
+    public let isOpen: Bool
+    public let nextOpening: String?
+}
+
+class OpeningHoursChecker {
+    public static func check(openingHours: OpeningHours, validateFor:Date = Date()) -> OpeningStatus {
+        guard let timeZone = TimeZone(identifier: openingHours.timezone) else {
+            return OpeningStatus(isOpen: false, nextOpening: nil)
+        }
+
+        let now = validateFor
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm"
+        timeFormatter.timeZone = timeZone
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = timeZone
+
+        let todayString = dateFormatter.string(from: now)
+        let nowTimeString = timeFormatter.string(from: now)
+        guard let nowTime = timeFormatter.date(from: nowTimeString) else {
+            return OpeningStatus(isOpen: false, nextOpening: nil)
+        }
+
+        // 🔒 Temporary Closure
+        if openingHours.temporaryClosure.contains(todayString) {
+            return OpeningStatus(isOpen: false, nextOpening: nil)
+        }
+
+        // 📅 Get day keys
+        let weekday = calendar.component(.weekday, from: now) // Sunday = 1
+        let todayKey = String(weekday == 1 ? 7 : weekday - 1) // 1=Monday, ..., 7=Sunday
+
+//        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
+//        let yesterdayString = dateFormatter.string(from: yesterday)
+        let yesterdayKey = String((weekday == 2 ? 7 : weekday - 2 == 0 ? 7 : weekday - 2))
+
+        // 🟨 1. Check Special for Today
+        if let specialToday = openingHours.special[todayString] {
+            if let status = checkPeriods(specialToday, nowTime: nowTime, formatter: timeFormatter) {
+                return status
+            }
+        }
+
+        // 🟩 2. Check Usual for Today
+        if let usualToday = openingHours.usual[todayKey] {
+            if let status = checkPeriods(usualToday, nowTime: nowTime, formatter: timeFormatter) {
+                return status
+            }
+        }
+
+        // 🟧 3. Check Yesterday for Overnight Hours
+        if let usualYesterday = openingHours.usual[yesterdayKey] {
+            for period in usualYesterday {
+                guard let startStr = period.start, let endStr = period.end,
+                      let start = timeFormatter.date(from: startStr),
+                      let end = timeFormatter.date(from: endStr),
+                      start > end // Indicates overnight
+                else { continue }
+
+                if nowTime <= end {
+                    return OpeningStatus(isOpen: true, nextOpening: nil)
+                }
+            }
+        }
+
+        // 🕐 4. Fallback – Return next opening time (first future start today)
+        if let next = openingHours.special[todayString]?.compactMap({ $0.start }).first ??
+                      openingHours.usual[todayKey]?.compactMap({ $0.start }).first {
+            return OpeningStatus(isOpen: false, nextOpening: "Opens at \(next) today")
+        }
+
+        return OpeningStatus(isOpen: false, nextOpening: nil)
+    }
+
+    private static func checkPeriods(
+        _ periods: [OpeningPeriod],
+        nowTime: Date,
+        formatter: DateFormatter
+    ) -> OpeningStatus? {
+        for period in periods {
+            if period.allDay == true {
+                return OpeningStatus(isOpen: true, nextOpening: nil)
+            }
+
+            guard let startStr = period.start, let endStr = period.end,
+                  let start = formatter.date(from: startStr),
+                  let end = formatter.date(from: endStr) else {
+                continue
+            }
+
+            if start <= end {
+                // Normal period
+                if nowTime >= start && nowTime <= end {
+                    return OpeningStatus(isOpen: true, nextOpening: nil)
+                }
+            } else {
+                // Overnight period
+                if nowTime >= start || nowTime <= end {
+                    return OpeningStatus(isOpen: true, nextOpening: nil)
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -19,8 +19,16 @@ struct OpeningHours: Codable {
         case temporaryClosure = "temporary_closure"
     }
     
-    static func openingHoursFrom(dictionary: [String: Any]) -> OpeningHours? {
+    static func openingHoursFrom(dictionary input: [String: Any]) -> OpeningHours? {
         do {
+            var dictionary = input
+            if dictionary["special"] == nil{
+                dictionary["special"] = [:]
+            }
+            if dictionary["temporary_closure"] == nil{
+                dictionary["temporary_closure"] = []
+            }
+            
             let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
             let decoder = JSONDecoder()
             return try decoder.decode(OpeningHours.self, from: data)

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -107,7 +107,7 @@ class OpeningHoursChecker {
     
     
     
-    public static func check(openingHours: OpeningHours, validateFor:Date = Date()) -> OpeningStatus {
+    public static func check(openingHours inputs: OpeningHours, validateFor:Date = Date()) -> OpeningStatus {
         
         func datesBetween(start: String, end: String, formatter: DateFormatter) -> [String] {
             guard let startDate = formatter.date(from: start),
@@ -130,7 +130,7 @@ class OpeningHoursChecker {
 
             return dates
         }
-        
+        var openingHours: OpeningHours = inputs
         guard let timeZone = TimeZone(identifier: openingHours.timezone) else {
             return OpeningStatus(isOpen: false, nextOpening: nil)
         }
@@ -152,7 +152,9 @@ class OpeningHoursChecker {
         guard let nowTime = timeFormatter.date(from: nowTimeString) else {
             return OpeningStatus(isOpen: false, nextOpening: nil)
         }
-
+        for week in 1...7 {
+            openingHours.usual[String(week)] = openingHours.usual[String(week)] ?? openingHours.usual["default"]
+        }
         // 🔒 Temporary Closure
         var temporaryClosureDays: [String] = []
         
@@ -193,14 +195,14 @@ class OpeningHoursChecker {
         }
 
         // 🟩 2. Check Usual for Today
-        if let usualToday = openingHours.usual[todayKey] {
+        if let usualToday = openingHours.usual[todayKey]{
             if let status = checkPeriods(usualToday, nowTime: nowTime, formatter: timeFormatter) {
                 return status
             }
         }
 
         // 🟧 3. Check Yesterday for Overnight Hours
-        if let usualYesterday = openingHours.usual[yesterdayKey] {
+        if let usualYesterday = openingHours.usual[yesterdayKey]{
             for period in usualYesterday {
                 guard let startStr = period.start, let endStr = period.end,
                       let start = timeFormatter.date(from: startStr),

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -11,7 +11,7 @@ import Foundation
 struct OpeningHours: Codable {
     var usual: [String: [OpeningPeriod]]
     let special: [String: [OpeningPeriod]]
-    let temporaryClosure: [String]
+    let temporaryClosure: [ClosuerPeriod]
     let timezone: String
 
     enum CodingKeys: String, CodingKey {
@@ -39,6 +39,15 @@ struct OpeningPeriod: Codable {
     enum CodingKeys: String, CodingKey {
         case start, end
         case allDay = "all-day"
+    }
+}
+
+struct ClosuerPeriod: Codable {
+    let start: String
+    let end: String
+   
+    enum CodingKeys: String, CodingKey {
+        case start, end
     }
 }
 
@@ -95,7 +104,33 @@ struct OpeningStatus {
 }
 
 class OpeningHoursChecker {
+    
+    
+    
     public static func check(openingHours: OpeningHours, validateFor:Date = Date()) -> OpeningStatus {
+        
+        func datesBetween(start: String, end: String, formatter: DateFormatter) -> [String] {
+            guard let startDate = formatter.date(from: start),
+                  let endDate = formatter.date(from: end) else {
+                return []
+            }
+
+            var currentDate = startDate
+            var dates: [String] = []
+
+            while currentDate <= endDate {
+                let formattedDate = formatter.string(from: currentDate)
+                dates.append(formattedDate)
+
+                guard let nextDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate) else {
+                    break
+                }
+                currentDate = nextDate
+            }
+
+            return dates
+        }
+        
         guard let timeZone = TimeZone(identifier: openingHours.timezone) else {
             return OpeningStatus(isOpen: false, nextOpening: nil)
         }
@@ -119,7 +154,23 @@ class OpeningHoursChecker {
         }
 
         // 🔒 Temporary Closure
-        if openingHours.temporaryClosure.contains(todayString) {
+        var temporaryClosureDays: [String] = []
+        
+        openingHours.temporaryClosure.forEach { (item) in
+            if (item.start != item.end){
+                // Calculate days between it
+                let datelist = datesBetween(start: item.start,end: item.end, formatter: dateFormatter)
+                datelist.forEach { closeDay in
+                    temporaryClosureDays.append(closeDay)
+                }
+            }
+            else{
+                temporaryClosureDays.append(item.start)
+            }
+            
+        }
+            
+        if temporaryClosureDays.contains(todayString) {
             return OpeningStatus(isOpen: false, nextOpening: nil)
         }
 

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -187,6 +187,9 @@ class OpeningHoursChecker {
             if let status = checkPeriods(specialToday, nowTime: nowTime, formatter: timeFormatter) {
                 return status
             }
+            else {
+                return OpeningStatus(isOpen: false, nextOpening: "Next Day Opening") //Close today due to special opening time
+            }
         }
 
         // 🟩 2. Check Usual for Today

--- a/Sources/WoosmapGeofencing/Business Logic/POI.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/POI.swift
@@ -45,8 +45,17 @@ public class POI {
     /// Address
     public var address: String?
     
+    private var _openNow: Bool = false
     /// Open Now
-    public var openNow: Bool = false
+    public var openNow: Bool {
+        get {
+            // process weekly_opening and get openNow status for current time
+            return _openNow
+        }
+//        set {
+//            _openNow = newValue
+//        }
+    }
     
     /// Country Code
     public var countryCode: String?
@@ -108,7 +117,7 @@ public class POI {
         self.zipCode = poiDB.zipCode
         self.radius = poiDB.radius
         self.address = poiDB.address
-        self.openNow = poiDB.openNow
+        self._openNow = poiDB.openNow
         self.countryCode = poiDB.countryCode
         self.tags = poiDB.tags
         self.types = poiDB.types
@@ -134,7 +143,7 @@ public class POI {
         newRec.zipCode = self.zipCode
         newRec.radius = self.radius
         newRec.address = self.address
-        newRec.openNow = self.openNow
+        newRec.openNow = self._openNow
         newRec.countryCode = self.countryCode
         newRec.tags = self.tags
         newRec.types = self.types

--- a/Sources/WoosmapGeofencing/Business Logic/POI.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/POI.swift
@@ -50,11 +50,11 @@ public class POI {
     public var openNow: Bool {
         get {
             // process weekly_opening and get openNow status for current time
-            return _openNow
+            return calculateOpenNow()
         }
-//        set {
-//            _openNow = newValue
-//        }
+        set {
+            _openNow = newValue
+        }
     }
     
     /// Country Code
@@ -173,6 +173,41 @@ public class POI {
             }
             return returnValues
         }
+    }
+    
+
+    /// Calculate openNow status from API response
+    ///  - Parameters:
+    ///     - timeStamp:  Currrent system time
+    func calculateOpenNow(timeStamp: Date = Date()) -> Bool {
+        let jsonStructure = try? JSONDecoder().decode(JSONAny.self, from:  self.jsonData ?? Data.init())
+        if let value = jsonStructure!.value as? [String: Any] {
+            if let features = value["features"] as? [[String: Any]] {
+                for feature in features {
+                    if let properties = feature["properties"] as? [String: Any] {
+                        if let openingHours = properties["opening_hours"] as? [String: Any] {
+                            if var openhrs:OpeningHours  = OpeningHours.openingHoursFrom(dictionary: openingHours) {
+                                if let weeklyOpening = properties["weekly_opening"] as? [String: Any]{
+                                    //Convert WeeklyOpening to OpeningHours as it more reliable from API
+                                    if let currentWeek:WeeklyOpening = WeeklyOpening.weeklyOpeningFrom(dictionary: weeklyOpening){
+                                        openhrs.usual = [:]
+                                        for (day, opening) in currentWeek.days {
+                                            openhrs.usual[day] =  opening.hours
+                                        }
+                                    }
+                                }
+                                //check open now status
+                                let status = OpeningHoursChecker.check(openingHours: openhrs,validateFor: timeStamp)
+                                return status.isOpen
+                            }
+                        }
+                        
+                    }
+                }
+            }
+        }
+        
+        return false
     }
 }
 

--- a/Sources/WoosmapGeofencing/Business Logic/POI.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/POI.swift
@@ -187,33 +187,6 @@ public class POI {
                     if let properties = feature["properties"] as? [String: Any] {
                         if let openingHours = properties["opening_hours"] as? [String: Any] {
                             if let openhrs:OpeningHours  = OpeningHours.openingHoursFrom(dictionary: openingHours) {
-//                                if let weeklyOpening = properties["weekly_opening"] as? [String: Any]{
-//                                    //Convert WeeklyOpening to OpeningHours as it more reliable from API
-//                                    if let currentWeek:WeeklyOpening = WeeklyOpening.weeklyOpeningFrom(dictionary: weeklyOpening){
-//                                        
-//                                        guard let timeZone = TimeZone(identifier: currentWeek.timezone) else {
-//                                            return false
-//                                        }
-//                                        var calendar = Calendar.current
-//                                        calendar.timeZone = timeZone
-//                                        let weekday = calendar.component(.weekday, from: timeStamp) // Sunday = 1
-//                                        let todayKey = weekday == 1 ? 7 : weekday - 1 // 1=Monday, ..., 7=Sunday
-//                                        var monndaysOpening: [OpeningPeriod]? = nil
-//                                        if(todayKey == 1){ // monday
-//                                            monndaysOpening = openhrs.usual["1"] ?? openhrs.usual["default"]
-//                                        }
-//                                      
-//                                        openhrs.usual = [:]
-//                                        for (day, opening) in currentWeek.days {
-//                                            openhrs.usual[day] =  opening.hours
-//                                        }
-//                                        // This is required as weekly_opening only return for current week and we want next week monday setting to calcualate openNow
-//                                        if let monndaysTime = monndaysOpening{
-//                                            openhrs.usual["1"] = monndaysTime
-//                                        }
-//                                        
-//                                    }
-//                                }
                                 //check open now status
                                 let status = OpeningHoursChecker.check(openingHours: openhrs,validateFor: timeStamp)
                                 return status.isOpen

--- a/Sources/WoosmapGeofencing/Business Logic/POI.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/POI.swift
@@ -190,10 +190,28 @@ public class POI {
                                 if let weeklyOpening = properties["weekly_opening"] as? [String: Any]{
                                     //Convert WeeklyOpening to OpeningHours as it more reliable from API
                                     if let currentWeek:WeeklyOpening = WeeklyOpening.weeklyOpeningFrom(dictionary: weeklyOpening){
+                                        
+                                        guard let timeZone = TimeZone(identifier: currentWeek.timezone) else {
+                                            return false
+                                        }
+                                        var calendar = Calendar.current
+                                        calendar.timeZone = timeZone
+                                        let weekday = calendar.component(.weekday, from: timeStamp) // Sunday = 1
+                                        let todayKey = weekday == 1 ? 7 : weekday - 1 // 1=Monday, ..., 7=Sunday
+                                        var monndaysOpening: [OpeningPeriod]? = nil
+                                        if(todayKey == 1){ // monday
+                                            monndaysOpening = openhrs.usual["1"] ?? openhrs.usual["default"]
+                                        }
+                                      
                                         openhrs.usual = [:]
                                         for (day, opening) in currentWeek.days {
                                             openhrs.usual[day] =  opening.hours
                                         }
+                                        // This is required as weekly_opening only return for current week and we want next week monday setting to calcualate openNow
+                                        if let monndaysTime = monndaysOpening{
+                                            openhrs.usual["1"] = monndaysTime
+                                        }
+                                        
                                     }
                                 }
                                 //check open now status

--- a/Sources/WoosmapGeofencing/Business Logic/POI.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/POI.swift
@@ -186,34 +186,34 @@ public class POI {
                 for feature in features {
                     if let properties = feature["properties"] as? [String: Any] {
                         if let openingHours = properties["opening_hours"] as? [String: Any] {
-                            if var openhrs:OpeningHours  = OpeningHours.openingHoursFrom(dictionary: openingHours) {
-                                if let weeklyOpening = properties["weekly_opening"] as? [String: Any]{
-                                    //Convert WeeklyOpening to OpeningHours as it more reliable from API
-                                    if let currentWeek:WeeklyOpening = WeeklyOpening.weeklyOpeningFrom(dictionary: weeklyOpening){
-                                        
-                                        guard let timeZone = TimeZone(identifier: currentWeek.timezone) else {
-                                            return false
-                                        }
-                                        var calendar = Calendar.current
-                                        calendar.timeZone = timeZone
-                                        let weekday = calendar.component(.weekday, from: timeStamp) // Sunday = 1
-                                        let todayKey = weekday == 1 ? 7 : weekday - 1 // 1=Monday, ..., 7=Sunday
-                                        var monndaysOpening: [OpeningPeriod]? = nil
-                                        if(todayKey == 1){ // monday
-                                            monndaysOpening = openhrs.usual["1"] ?? openhrs.usual["default"]
-                                        }
-                                      
-                                        openhrs.usual = [:]
-                                        for (day, opening) in currentWeek.days {
-                                            openhrs.usual[day] =  opening.hours
-                                        }
-                                        // This is required as weekly_opening only return for current week and we want next week monday setting to calcualate openNow
-                                        if let monndaysTime = monndaysOpening{
-                                            openhrs.usual["1"] = monndaysTime
-                                        }
-                                        
-                                    }
-                                }
+                            if let openhrs:OpeningHours  = OpeningHours.openingHoursFrom(dictionary: openingHours) {
+//                                if let weeklyOpening = properties["weekly_opening"] as? [String: Any]{
+//                                    //Convert WeeklyOpening to OpeningHours as it more reliable from API
+//                                    if let currentWeek:WeeklyOpening = WeeklyOpening.weeklyOpeningFrom(dictionary: weeklyOpening){
+//                                        
+//                                        guard let timeZone = TimeZone(identifier: currentWeek.timezone) else {
+//                                            return false
+//                                        }
+//                                        var calendar = Calendar.current
+//                                        calendar.timeZone = timeZone
+//                                        let weekday = calendar.component(.weekday, from: timeStamp) // Sunday = 1
+//                                        let todayKey = weekday == 1 ? 7 : weekday - 1 // 1=Monday, ..., 7=Sunday
+//                                        var monndaysOpening: [OpeningPeriod]? = nil
+//                                        if(todayKey == 1){ // monday
+//                                            monndaysOpening = openhrs.usual["1"] ?? openhrs.usual["default"]
+//                                        }
+//                                      
+//                                        openhrs.usual = [:]
+//                                        for (day, opening) in currentWeek.days {
+//                                            openhrs.usual[day] =  opening.hours
+//                                        }
+//                                        // This is required as weekly_opening only return for current week and we want next week monday setting to calcualate openNow
+//                                        if let monndaysTime = monndaysOpening{
+//                                            openhrs.usual["1"] = monndaysTime
+//                                        }
+//                                        
+//                                    }
+//                                }
                                 //check open now status
                                 let status = OpeningHoursChecker.check(openingHours: openhrs,validateFor: timeStamp)
                                 return status.isOpen

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -21,9 +21,9 @@ class POIDBTest: XCTestCase {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm"
         formatter.timeZone = TimeZone(identifier: "Asia/Kolkata") // Set your desired timezone
-        sundayDate = formatter.date(from: "2025-08-03 15:00")!
+        sundayDate = formatter.date(from: "2025-08-03 10:00")!
     
-        weekDate = formatter.date(from: "2025-07-28 16:00")!
+        weekDate = formatter.date(from: "2025-07-28 10:00")!
     }
 
     override func setUpWithError() throws {
@@ -36,292 +36,502 @@ class POIDBTest: XCTestCase {
     
     func testOpenForToday() throws {
         let poi = POI()
+        
+        /// Default 08 to 13 sunday 10 to 14
         let testdata = """
         {
-          "type": "FeatureCollection",
-          "features": [
-            {
-              "type": "Feature",
-              "properties": {
-                "store_id": "18409_190784",
-                "name": "Elphinstone Road",
-                "contact": {},
-                "address": {
-                  "lines": [
-                    "Indiabulls Finance Centre",
-                    "Elphinstone Road (West)"
-                  ],
-                  "country_code": null,
-                  "city": "Mumbai",
-                  "zipcode": "400013"
-                },
-                "user_properties": {
-                  "radius": 13
-                },
-                "tags": [
-                  "station",
-                  "Group",
-                  "Office"
-                ],
-                "types": [],
-                "last_updated": "2025-07-28T08:27:10.122916+00:00",
-                "distance": 2323.95810781,
-                "open": {
-                  "open_now": true,
-                  "open_hours": [
-                    {
-                      "all-day": true
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "contact": {},
+                        "address": {
+                            "lines": [
+                                "Indiabulls Finance Centre",
+                                "Elphinstone Road (West)"
+                            ],
+                            "country_code": null,
+                            "city": "Mumbai",
+                            "zipcode": "400013"
+                        },
+                        "user_properties": {
+                            "radius": 13
+                        },
+                        "tags": [
+                            "station",
+                            "Group",
+                            "Office"
+                        ],
+                        "types": [],
+                        "last_updated": "2025-07-28T13:01:35.696876+00:00",
+                        "distance": 2323.95810781,
+                        "open": {
+                            "open_now": false,
+                            "open_hours": [
+                                {
+                                    "end": "13:00",
+                                    "start": "08:00"
+                                }
+                            ],
+                            "week_day": 1,
+                            "next_opening": {
+                                "day": "2025-07-29",
+                                "start": "08:00",
+                                "end": "13:00"
+                            }
+                        },
+                        "weekly_opening": {
+                            "timezone": "Asia/Kolkata",
+                            "1": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "2": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "3": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "4": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "5": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "6": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "7": {
+                                "hours": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            }
+                        },
+                        "opening_hours": {
+                            "usual": {
+                                "7": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "default": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ]
+                            },
+                            "special": {},
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": []
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
                     }
-                  ],
-                  "week_day": 1,
-                  "current_slice": {
-                    "all-day": true
-                  }
-                },
-                "weekly_opening": {
-                  "1": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "2": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "3": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "4": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "5": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "6": {
-                    "hours": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "isSpecial": false
-                  },
-                  "7": {
-                    "hours": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "isSpecial": false
-                  },
-                  "timezone": "Asia/Kolkata"
-                },
-                "opening_hours": {
-                  "usual": {
-                    "7": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "default": [
-                      {
-                        "all-day": true
-                      }
-                    ]
-                  },
-                  "special": {},
-                  "timezone": "Asia/Kolkata",
-                  "temporary_closure": []
                 }
-              },
-              "geometry": {
-                "type": "Point",
-                "coordinates": [
-                  72.835595,
-                  19.009997
-                ]
-              }
-            }
-          ]
+            ]
         }
         """
         poi.jsonData = testdata.data(using: .utf8)!
-        let result = poi.calculateOpenNow(timeStamp: weekDate)
+        let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
         XCTAssertTrue(result)
+        
+
+        let oneHourLater = Calendar.current.date(byAdding: .hour, value: 1, to: weekDate)!
+        let result1 = poi.calculateOpenNow(timeStamp: oneHourLater) //11 AM
+        XCTAssertTrue(result1)
+        
+        let threeHourLater = Calendar.current.date(byAdding: .hour, value: 3, to: weekDate)!
+        let result2 = poi.calculateOpenNow(timeStamp: threeHourLater) //13 AM
+        XCTAssertTrue(result2)
+        
+        let fourHourLater = Calendar.current.date(byAdding: .hour, value: 4, to: weekDate)!
+        let result3 = poi.calculateOpenNow(timeStamp: fourHourLater) //14 AM
+        XCTAssertFalse(result3)
+        
+        let result4 = poi.calculateOpenNow(timeStamp: sundayDate) //sunday 10 AM
+        XCTAssertTrue(result4)
+        
+        let oneHourbefore = Calendar.current.date(byAdding: .hour, value: -1, to: sundayDate)!
+        let result5 = poi.calculateOpenNow(timeStamp: oneHourbefore) //sunday 9 AM
+        XCTAssertFalse(result5)
+        
     }
     
-    func testCloseForToday() throws {
+    
+    
+    func testSpecialDay() throws {
         let poi = POI()
+        
+        /// Default 08 to 13
+        /// sunday 10 to 14
+        ///
+        /// Special day     28 16 -16 open
+        ///            29 close all day
         let testdata = """
         {
-          "type": "FeatureCollection",
-          "features": [
-            {
-              "type": "Feature",
-              "properties": {
-                "store_id": "18409_190784",
-                "name": "Elphinstone Road",
-                "contact": {},
-                "address": {
-                  "lines": [
-                    "Indiabulls Finance Centre",
-                    "Elphinstone Road (West)"
-                  ],
-                  "country_code": null,
-                  "city": "Mumbai",
-                  "zipcode": "400013"
-                },
-                "user_properties": {
-                  "radius": 13
-                },
-                "tags": [
-                  "station",
-                  "Group",
-                  "Office"
-                ],
-                "types": [],
-                "last_updated": "2025-07-28T08:27:10.122916+00:00",
-                "distance": 2323.95810781,
-                "open": {
-                  "open_now": true,
-                  "open_hours": [
-                    {
-                      "all-day": true
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "contact": {},
+                        "address": {
+                            "lines": [
+                                "Indiabulls Finance Centre",
+                                "Elphinstone Road (West)"
+                            ],
+                            "country_code": null,
+                            "city": "Mumbai",
+                            "zipcode": "400013"
+                        },
+                        "user_properties": {
+                            "radius": 13
+                        },
+                        "tags": [
+                            "station",
+                            "Group",
+                            "Office"
+                        ],
+                        "types": [],
+                        "last_updated": "2025-07-28T13:15:37.411637+00:00",
+                        "distance": 2323.95810781,
+                        "open": {
+                            "open_now": false,
+                            "open_hours": [
+                                {
+                                    "end": "16:00",
+                                    "start": "15:00"
+                                }
+                            ],
+                            "week_day": 1,
+                            "next_opening": {
+                                "day": "2025-07-30",
+                                "start": "08:00",
+                                "end": "13:00"
+                            }
+                        },
+                        "weekly_opening": {
+                            "timezone": "Asia/Kolkata",
+                            "1": {
+                                "hours": [
+                                    {
+                                        "end": "16:00",
+                                        "start": "15:00"
+                                    }
+                                ],
+                                "isSpecial": true
+                            },
+                            "2": {
+                                "hours": [],
+                                "isSpecial": true
+                            },
+                            "3": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "4": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "5": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "6": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "7": {
+                                "hours": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            }
+                        },
+                        "opening_hours": {
+                            "usual": {
+                                "7": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "default": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ]
+                            },
+                            "special": {
+                                "2025-07-28": [
+                                    {
+                                        "end": "16:00",
+                                        "start": "15:00"
+                                    }
+                                ],
+                                "2025-07-29": []
+                            },
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": []
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
                     }
-                  ],
-                  "week_day": 1,
-                  "current_slice": {
-                    "all-day": true
-                  }
-                },
-                "weekly_opening": {
-                  "1": {
-                    "hours": [
-                        {
-                          "end": "13:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "2": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "3": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "4": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "5": {
-                    "hours": [
-                        {
-                          "end": "20:00",
-                          "start": "08:00"
-                        }
-                    ],
-                    "isSpecial": false
-                  },
-                  "6": {
-                    "hours": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "isSpecial": false
-                  },
-                  "7": {
-                    "hours": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "isSpecial": false
-                  },
-                  "timezone": "Asia/Kolkata"
-                },
-                "opening_hours": {
-                  "usual": {
-                    "7": [
-                      {
-                        "end": "20:00",
-                        "start": "08:00"
-                      }
-                    ],
-                    "default": [
-                      {
-                        "all-day": true
-                      }
-                    ]
-                  },
-                  "special": {},
-                  "timezone": "Asia/Kolkata",
-                  "temporary_closure": []
                 }
-              },
-              "geometry": {
-                "type": "Point",
-                "coordinates": [
-                  72.835595,
-                  19.009997
-                ]
-              }
-            }
-          ]
+            ]
         }
         """
         poi.jsonData = testdata.data(using: .utf8)!
-        let result = poi.calculateOpenNow(timeStamp: weekDate)
+        let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
         XCTAssertFalse(result)
+        
+        let fiveHourAfter = Calendar.current.date(byAdding: .hour, value: 5, to: weekDate)!
+        let result1 = poi.calculateOpenNow(timeStamp: fiveHourAfter) // 3 PM
+        XCTAssertTrue(result1)
+        
+        let nextDayAfter = Calendar.current.date(byAdding: .day, value: 1, to: weekDate)!
+        let result2 = poi.calculateOpenNow(timeStamp: nextDayAfter) //  next day 10 AM
+        XCTAssertFalse(result2)
+        
+        let next2DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
+        let result3 = poi.calculateOpenNow(timeStamp: next2DayAfter) //  on 30th day 10 AM
+        XCTAssertTrue(result3)
     }
     
+    
+    func testTemporaryCloseDay() throws {
+        let poi = POI()
+        
+        /// Default 08 to 13
+        /// sunday 10 to 14
+        ///
+        /// TemporaryClose     28 -29 close all day
+        ///               31 close all day
+        let testdata = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "contact": {},
+                        "address": {
+                            "lines": [
+                                "Indiabulls Finance Centre",
+                                "Elphinstone Road (West)"
+                            ],
+                            "country_code": null,
+                            "city": "Mumbai",
+                            "zipcode": "400013"
+                        },
+                        "user_properties": {
+                            "radius": 13
+                        },
+                        "tags": [
+                            "station",
+                            "Group",
+                            "Office"
+                        ],
+                        "types": [],
+                        "last_updated": "2025-07-28T13:28:14.594150+00:00",
+                        "distance": 2323.95810781,
+                        "open": {
+                            "open_now": false,
+                            "open_hours": [],
+                            "week_day": 1,
+                            "next_opening": {
+                                "day": "2025-07-30",
+                                "start": "08:00",
+                                "end": "13:00"
+                            }
+                        },
+                        "weekly_opening": {
+                            "timezone": "Asia/Kolkata",
+                            "1": {
+                                "hours": [],
+                                "isSpecial": true
+                            },
+                            "2": {
+                                "hours": [],
+                                "isSpecial": true
+                            },
+                            "3": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "4": {
+                                "hours": [],
+                                "isSpecial": true
+                            },
+                            "5": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "6": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "7": {
+                                "hours": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            }
+                        },
+                        "opening_hours": {
+                            "usual": {
+                                "7": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "default": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ]
+                            },
+                            "special": {},
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": [
+                                {
+                                    "end": "2025-07-29",
+                                    "start": "2025-07-28"
+                                },
+                                {
+                                    "end": "2025-07-31",
+                                    "start": "2025-07-31"
+                                }
+                            ]
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
+                    }
+                }
+            ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+        let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
+        XCTAssertFalse(result)
+        
+        let nextDayAfter = Calendar.current.date(byAdding: .day, value: 1, to: weekDate)!
+        let result1 = poi.calculateOpenNow(timeStamp: nextDayAfter) //  next day 10 AM
+        XCTAssertFalse(result1)
+
+        let next2DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
+        let result2 = poi.calculateOpenNow(timeStamp: next2DayAfter) //  on 30th day 10 AM
+        XCTAssertTrue(result2)
+        
+        let next3DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
+        let result3 = poi.calculateOpenNow(timeStamp: next3DayAfter) //  on 31th day 10 AM
+        XCTAssertTrue(result3)
+    }
 }

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -534,4 +534,178 @@ class POIDBTest: XCTestCase {
         let result3 = poi.calculateOpenNow(timeStamp: next3DayAfter) //  on 31th day 10 AM
         XCTAssertTrue(result3)
     }
+    
+    
+    func testSpilloverDay() throws {
+        let poi = POI()
+        
+        /// Default 08 to 13
+        /// sunday 10 to 14
+        ///
+        /// special day     28 open 15 to 20
+     
+        let testdata = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "contact": {},
+                        "address": {
+                            "lines": [
+                                "Indiabulls Finance Centre",
+                                "Elphinstone Road (West)"
+                            ],
+                            "country_code": null,
+                            "city": "Mumbai",
+                            "zipcode": "400013"
+                        },
+                        "user_properties": {
+                            "radius": 13
+                        },
+                        "tags": [
+                            "station",
+                            "Group",
+                            "Office"
+                        ],
+                        "types": [],
+                        "last_updated": "2025-07-28T14:15:30.973303+00:00",
+                        "distance": 2323.95810781,
+                        "open": {
+                            "open_now": true,
+                            "open_hours": [
+                                {
+                                    "end": "20:00",
+                                    "start": "15:00"
+                                }
+                            ],
+                            "week_day": 1,
+                            "current_slice": {
+                                "end": "20:00",
+                                "start": "15:00"
+                            }
+                        },
+                        "weekly_opening": {
+                            "timezone": "Asia/Kolkata",
+                            "1": {
+                                "hours": [
+                                    {
+                                        "end": "20:00",
+                                        "start": "15:00"
+                                    }
+                                ],
+                                "isSpecial": true
+                            },
+                            "2": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "3": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "4": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "5": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "6": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "7": {
+                                "hours": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            }
+                        },
+                        "opening_hours": {
+                            "usual": {
+                                "7": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "default": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ]
+                            },
+                            "special": {
+                                "2025-07-28": [
+                                    {
+                                        "end": "20:00",
+                                        "start": "15:00"
+                                    }
+                                ]
+                            },
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": []
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
+                    }
+                }
+            ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+        let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
+        XCTAssertFalse(result)
+        
+        let nextDayAfter = Calendar.current.date(byAdding: .day, value: 7, to: weekDate)!
+        let result1 = poi.calculateOpenNow(timeStamp: nextDayAfter) //  next week 10 AM shoild be open
+        XCTAssertTrue(result1)
+//
+//        let next2DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
+//        let result2 = poi.calculateOpenNow(timeStamp: next2DayAfter) //  on 30th day 10 AM
+//        XCTAssertTrue(result2)
+//        
+//        let next3DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
+//        let result3 = poi.calculateOpenNow(timeStamp: next3DayAfter) //  on 31th day 10 AM
+//        XCTAssertTrue(result3)
+    }
 }

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -708,4 +708,169 @@ class POIDBTest: XCTestCase {
         let result2 = poi.calculateOpenNow(timeStamp: hr2sbefore) //  on 8 AM
         XCTAssertTrue(result2)
     }
+    
+    func testWrongInput() throws {
+        let poi = POI()
+        
+        /// Default 08 to 13
+        /// sunday 10 to 14
+        ///
+        /// special day     28 open 15 to 20
+     
+        let testdata = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "contact": {},
+                        "address": {
+                            "lines": [
+                                "Indiabulls Finance Centre",
+                                "Elphinstone Road (West)"
+                            ],
+                            "country_code": null,
+                            "city": "Mumbai",
+                            "zipcode": "400013"
+                        },
+                        "user_properties": {
+                            "radius": 13
+                        },
+                        "tags": [
+                            "station",
+                            "Group",
+                            "Office"
+                        ],
+                        "types": [],
+                        "last_updated": "2025-07-28T14:15:30.973303+00:00",
+                        "distance": 2323.95810781,
+                        "open": {
+                            "open_now": true,
+                            "open_hours": [
+                                {
+                                    "end": "20:00",
+                                    "start": "15:00"
+                                }
+                            ],
+                            "week_day": 1,
+                            "current_slice": {
+                                "end": "20:00",
+                                "start": "15:00"
+                            }
+                        },
+                        "weekly_opening": {
+                            "timezone": "Asia/Kolkata",
+                            "1": {
+                                "hours": [
+                                    {
+                                        "end": "20:00",
+                                        "start": "15:00"
+                                    }
+                                ],
+                                "isSpecial": true
+                            },
+                            "2": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "3": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "4": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "5": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "6": {
+                                "hours": [
+                                    {
+                                        "end": "13:00",
+                                        "start": "08:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            },
+                            "7": {
+                                "hours": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "isSpecial": false
+                            }
+                        },
+                        "opening_hours": {
+                            "usual": {
+                                "7": [
+                                    {
+                                        "end": "14:00",
+                                        "start": "10:00"
+                                    }
+                                ],
+                                "default": [
+                                    {
+                                        "end": "",
+                                        "start": "08:00"
+                                    }
+                                ]
+                            },
+                            "special": {
+                                "2025-07-28": [
+                                    {
+                                        "end": "20:00",
+                                        "start": "15:00"
+                                    },
+                                    {
+                                        "end": "08:00",
+                                        "start": "07:00"
+                                    }
+                                ]
+                            },
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": []
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
+                    }
+                }
+            ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+        let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
+        XCTAssertFalse(result)
+    }
 }

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -1,0 +1,327 @@
+//
+//  POITests.swift
+//  WoosmapGeofencingCoreTests
+//
+//  Created by WGS on 28/07/25.
+//  Copyright © 2025 Web Geo Services. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import WoosmapGeofencingCore
+
+class POIDBTest: XCTestCase {
+    
+    
+    var sundayDate: Date = Date()
+    var weekDate: Date = Date()
+    
+    override func setUp() {
+        super.setUp()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.timeZone = TimeZone(identifier: "Asia/Kolkata") // Set your desired timezone
+        sundayDate = formatter.date(from: "2025-08-03 15:00")!
+    
+        weekDate = formatter.date(from: "2025-07-28 16:00")!
+    }
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testOpenForToday() throws {
+        let poi = POI()
+        let testdata = """
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {
+                "store_id": "18409_190784",
+                "name": "Elphinstone Road",
+                "contact": {},
+                "address": {
+                  "lines": [
+                    "Indiabulls Finance Centre",
+                    "Elphinstone Road (West)"
+                  ],
+                  "country_code": null,
+                  "city": "Mumbai",
+                  "zipcode": "400013"
+                },
+                "user_properties": {
+                  "radius": 13
+                },
+                "tags": [
+                  "station",
+                  "Group",
+                  "Office"
+                ],
+                "types": [],
+                "last_updated": "2025-07-28T08:27:10.122916+00:00",
+                "distance": 2323.95810781,
+                "open": {
+                  "open_now": true,
+                  "open_hours": [
+                    {
+                      "all-day": true
+                    }
+                  ],
+                  "week_day": 1,
+                  "current_slice": {
+                    "all-day": true
+                  }
+                },
+                "weekly_opening": {
+                  "1": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "2": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "3": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "4": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "5": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "6": {
+                    "hours": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "isSpecial": false
+                  },
+                  "7": {
+                    "hours": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "isSpecial": false
+                  },
+                  "timezone": "Asia/Kolkata"
+                },
+                "opening_hours": {
+                  "usual": {
+                    "7": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "default": [
+                      {
+                        "all-day": true
+                      }
+                    ]
+                  },
+                  "special": {},
+                  "timezone": "Asia/Kolkata",
+                  "temporary_closure": []
+                }
+              },
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  72.835595,
+                  19.009997
+                ]
+              }
+            }
+          ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+        let result = poi.calculateOpenNow(timeStamp: weekDate)
+        XCTAssertTrue(result)
+    }
+    
+    func testCloseForToday() throws {
+        let poi = POI()
+        let testdata = """
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {
+                "store_id": "18409_190784",
+                "name": "Elphinstone Road",
+                "contact": {},
+                "address": {
+                  "lines": [
+                    "Indiabulls Finance Centre",
+                    "Elphinstone Road (West)"
+                  ],
+                  "country_code": null,
+                  "city": "Mumbai",
+                  "zipcode": "400013"
+                },
+                "user_properties": {
+                  "radius": 13
+                },
+                "tags": [
+                  "station",
+                  "Group",
+                  "Office"
+                ],
+                "types": [],
+                "last_updated": "2025-07-28T08:27:10.122916+00:00",
+                "distance": 2323.95810781,
+                "open": {
+                  "open_now": true,
+                  "open_hours": [
+                    {
+                      "all-day": true
+                    }
+                  ],
+                  "week_day": 1,
+                  "current_slice": {
+                    "all-day": true
+                  }
+                },
+                "weekly_opening": {
+                  "1": {
+                    "hours": [
+                        {
+                          "end": "13:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "2": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "3": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "4": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "5": {
+                    "hours": [
+                        {
+                          "end": "20:00",
+                          "start": "08:00"
+                        }
+                    ],
+                    "isSpecial": false
+                  },
+                  "6": {
+                    "hours": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "isSpecial": false
+                  },
+                  "7": {
+                    "hours": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "isSpecial": false
+                  },
+                  "timezone": "Asia/Kolkata"
+                },
+                "opening_hours": {
+                  "usual": {
+                    "7": [
+                      {
+                        "end": "20:00",
+                        "start": "08:00"
+                      }
+                    ],
+                    "default": [
+                      {
+                        "all-day": true
+                      }
+                    ]
+                  },
+                  "special": {},
+                  "timezone": "Asia/Kolkata",
+                  "temporary_closure": []
+                }
+              },
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  72.835595,
+                  19.009997
+                ]
+              }
+            }
+          ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+        let result = poi.calculateOpenNow(timeStamp: weekDate)
+        XCTAssertFalse(result)
+    }
+    
+}

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -674,6 +674,10 @@ class POIDBTest: XCTestCase {
                                     {
                                         "end": "20:00",
                                         "start": "15:00"
+                                    },
+                                    {
+                                        "end": "08:00",
+                                        "start": "07:00"
                                     }
                                 ]
                             },
@@ -699,13 +703,9 @@ class POIDBTest: XCTestCase {
         let nextDayAfter = Calendar.current.date(byAdding: .day, value: 7, to: weekDate)!
         let result1 = poi.calculateOpenNow(timeStamp: nextDayAfter) //  next week 10 AM shoild be open
         XCTAssertTrue(result1)
-//
-//        let next2DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
-//        let result2 = poi.calculateOpenNow(timeStamp: next2DayAfter) //  on 30th day 10 AM
-//        XCTAssertTrue(result2)
-//        
-//        let next3DayAfter = Calendar.current.date(byAdding: .day, value: 2, to: weekDate)!
-//        let result3 = poi.calculateOpenNow(timeStamp: next3DayAfter) //  on 31th day 10 AM
-//        XCTAssertTrue(result3)
+
+        let hr2sbefore = Calendar.current.date(byAdding: .hour, value: -2, to: weekDate)!
+        let result2 = poi.calculateOpenNow(timeStamp: hr2sbefore) //  on 8 AM
+        XCTAssertTrue(result2)
     }
 }

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,1 +1,1 @@
-- Updated CI/CD for automated publishing 
+- Updated:  Calculate OpenNow status for POI in realtime

--- a/WoosmapGeofencingCore.podspec
+++ b/WoosmapGeofencingCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'WoosmapGeofencingCore'
-  s.version = '4.3.13'
+  s.version = '4.3.14'
   s.license = 'BSD'
   s.summary = 'Geofencing in Swift'
   s.homepage = 'https://github.com/woosmap/geofencing-core-ios-sdk'

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.3.13;
+				MARKETING_VERSION = 4.3.14;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -690,7 +690,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.3.13;
+				MARKETING_VERSION = 4.3.14;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		5F468E092A2499DF006F6D94 /* Logarithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F468DF82A2499DF006F6D94 /* Logarithm.swift */; };
 		5F5CD5EA28A6302C0074D7DD /* DurationLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */; };
 		5F84A8142AB425A2002B1735 /* WoosLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F84A8132AB425A2002B1735 /* WoosLogger.swift */; };
+		5F84E5A12E377E9100F04234 /* POITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F84E5A02E377E9100F04234 /* POITests.swift */; };
+		5F84E5A32E378BDB00F04234 /* OpeningHoursChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F84E5A22E378BDB00F04234 /* OpeningHoursChecker.swift */; };
 		5FB3E7A32872F2BE0035653E /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB3E7A22872F2BE0035653E /* LocationService.swift */; };
 		5FB3E7A52872F3170035653E /* LocationServiceCoreImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB3E7A42872F3170035653E /* LocationServiceCoreImpl.swift */; };
 		A24796FF2726DF700081AADC /* Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24796FE2726DF700081AADC /* Distance.swift */; };
@@ -101,6 +103,8 @@
 		5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationLogTest.swift; sourceTree = "<group>"; };
 		5F6FD2852B95B980009E6A49 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		5F84A8132AB425A2002B1735 /* WoosLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WoosLogger.swift; sourceTree = "<group>"; };
+		5F84E5A02E377E9100F04234 /* POITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POITests.swift; sourceTree = "<group>"; };
+		5F84E5A22E378BDB00F04234 /* OpeningHoursChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursChecker.swift; sourceTree = "<group>"; };
 		5FB3E7A22872F2BE0035653E /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		5FB3E7A42872F3170035653E /* LocationServiceCoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceCoreImpl.swift; sourceTree = "<group>"; };
 		A216FBA923E9CEA70003AAC8 /* WoosmapGeofencingCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WoosmapGeofencingCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -303,6 +307,7 @@
 				A248052D27DA5E8900E5B7CD /* LogSearchAPI.swift */,
 				5FB3E7A42872F3170035653E /* LocationServiceCoreImpl.swift */,
 				5F84A8132AB425A2002B1735 /* WoosLogger.swift */,
+				5F84E5A22E378BDB00F04234 /* OpeningHoursChecker.swift */,
 			);
 			path = "Business Logic";
 			sourceTree = "<group>";
@@ -323,6 +328,7 @@
 				A262B9C724E29ADF00EB621F /* Info.plist */,
 				A262B9C624E29ADF00EB621F /* ZoiQualifierTests.swift */,
 				5F5CD5E928A6302C0074D7DD /* DurationLogTest.swift */,
+				5F84E5A02E377E9100F04234 /* POITests.swift */,
 			);
 			name = WoosmapGeofencingTests;
 			path = Tests/WoosmapGeofencingTests;
@@ -445,6 +451,7 @@
 			files = (
 				A262B9D724E29B0000EB621F /* SearchAPiJson.swift in Sources */,
 				A2710EEB25B5C8C400AF62F5 /* POI.swift in Sources */,
+				5F84E5A32E378BDB00F04234 /* OpeningHoursChecker.swift in Sources */,
 				A262B9D524E29B0000EB621F /* FIGMM.swift in Sources */,
 				5F468E012A2499DF006F6D94 /* Array+Extensions.swift in Sources */,
 				5FB3E7A52872F3170035653E /* LocationServiceCoreImpl.swift in Sources */,
@@ -491,6 +498,7 @@
 			files = (
 				A26E646125B98BDD00EDBA72 /* DelayDataDurationTests.swift in Sources */,
 				5F5CD5EA28A6302C0074D7DD /* DurationLogTest.swift in Sources */,
+				5F84E5A12E377E9100F04234 /* POITests.swift in Sources */,
 				A262B9C824E29ADF00EB621F /* FIGMMCreatorTests.swift in Sources */,
 				A2DDC91B25C86B0C00C90486 /* DatabaseTests.swift in Sources */,
 				A262B9C924E29ADF00EB621F /* ZoiQualifierTests.swift in Sources */,


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
Woosmap/geofencing-enterprise-ios-sdk#135

## Describe your changes
Store API returns `opening_hours` in the format of **openNow specification**, reading it and checking it against the current system time to decide whether to set the openNow flag.

## How to test
Added unittest case to handle various formats of opening hours returned from the store API. Please run unit tests to check functionality 

--- OR ---
Run this click& collect app on your phone [click-collect-main.zip](https://github.com/user-attachments/files/21507007/click-collect-main.zip)

<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-30 at 15 37 54" src="https://github.com/user-attachments/assets/860bd120-a526-4786-9bfa-7feb03452b32" />


This app log store opening status in notification as well as log when you react near to POI

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
<!-- Create issues to track any required documentation changes and include them here -->

### Libs/SDKs
<!-- Create issues to track any required library or SDK changes and include them here -->
