### PR TITLE
Replace DispatchQueue.main.async with Task { @MainActor }

### DIFF
--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 24.x
         registry-url: https://registry.npmjs.org/
 
     - name: Checkout base branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.base_ref }}
         submodules: recursive
@@ -76,7 +76,7 @@ jobs:
         rm -rf sdk
 
     - name: Checkout PR source branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         
@@ -102,7 +102,7 @@ jobs:
         exit 1
 
     - name: Refetch PR source branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: "${{ github.head_ref || github.ref_name }}"
         submodules: recursive
@@ -140,7 +140,7 @@ jobs:
       steps:
 
         - name: Refetch PR source branch
-          uses: actions/checkout@v3
+          uses: actions/checkout@v6
           with:
             ref: "${{ github.head_ref || github.ref_name }}"
             

--- a/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/LocationServiceCoreImpl.swift
@@ -130,7 +130,7 @@ public class LocationServiceCoreImpl: NSObject,
             }
         }
         else{
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.locationManager?.startUpdatingLocation()
                 if visitEnable {
                     self.locationManager?.startMonitoringVisits()
@@ -154,7 +154,7 @@ public class LocationServiceCoreImpl: NSObject,
                 self.locationManager?.stopUpdatingLocation()
             }
             else{
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self.locationManager?.stopUpdatingLocation()
                 }
             }
@@ -297,7 +297,7 @@ public class LocationServiceCoreImpl: NSObject,
             self.updateRegionMonitoring()
         }
         else{
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.updateRegionMonitoring()
             }
         }
@@ -859,7 +859,6 @@ public class LocationServiceCoreImpl: NSObject,
         if let url = url.url{
             // Call API Distance
             woosApiCall(with: url) {(data, response, error) in
-                //DispatchQueue.main.async {
                     if let response = response as? HTTPURLResponse {
                         if response.statusCode != 200 {
                             if(WoosLog.isValidLevel(level: .error)){
@@ -892,7 +891,6 @@ public class LocationServiceCoreImpl: NSObject,
                             delegateDistance.distanceAPIResponse(distance: distance)
                         }
                     }
-                //}
             }
         }
     }
@@ -1113,7 +1111,7 @@ public class LocationServiceCoreImpl: NSObject,
         
         let apiURLSession = URLSession(configuration: apiConfigtation)
         let task = apiURLSession.dataTask(with: url) { data, response, error in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 completionHandler(data, response, error)
             }
         }

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,1 +1,1 @@
-- Updated:  Calculate OpenNow status for POI in realtime
+- Updated:  improved main-thread handling for better reliability and performance

--- a/WoosmapGeofencingCore.podspec
+++ b/WoosmapGeofencingCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'WoosmapGeofencingCore'
-  s.version = '4.3.14'
+  s.version = '4.4.0'
   s.license = 'BSD'
   s.summary = 'Geofencing in Swift'
   s.homepage = 'https://github.com/woosmap/geofencing-core-ios-sdk'

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.3.14;
+				MARKETING_VERSION = 4.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -690,7 +690,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.3.14;
+				MARKETING_VERSION = 4.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Issue
Related to Woosmap/geofencing-enterprise-ios-sdk#153

## Describe your changes
Replaces `DispatchQueue.main.async { ... }` with Swift concurrency `Task { @MainActor in ... }` in `LocationServiceCoreImpl.swift` for main-thread hops that re-enter region monitoring, location update start/stop, and the Woosmap API completion handler. Also removes a couple of commented-out `DispatchQueue.main.async` blocks that are no longer needed.

Touched call sites:
- `startUpdatingLocation()` fallback in the non-main-thread branch
- `stopUpdatingLocation()` fallback in the non-main-thread branch
- `updateRegionMonitoring()` fallback in `didUpdateLocations`
- `woosApiCall` URLSession completion dispatch

## How to test
1. Check out `dev/mainactor` of `geofencing-core-ios-sdk` and build the parent SDK that consumes it.
2. Run the Sample app on a device/simulator with "Always" location authorization.
3. Verify that:
   - Location updates are received and `currentLocation` is set.
   - Region entries/exits (POI + custom) still fire on the main thread.
   - Distance/Search API callbacks still deliver on the main thread.
4. Run the existing unit test suite — no new threading warnings or main-thread checker failures should appear.

## Checklist:
- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
N/A — internal threading change, no public API surface affected.

### Libs/SDKs
Consumed by `Woosmap/WoosmapGeofencing-iOS` (#153). The parent SDK's submodule pointer will need to be bumped to this commit once merged.