### PR TITLE
Fix overnight opening hours spilling past midnight (#163)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch SDK version from Podspec
         id: extract_version
@@ -35,7 +35,7 @@ jobs:
           git push origin ${{ steps.extract_version.outputs.sdk_version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.extract_version.outputs.sdk_version }}
           body_path: WHATSNEW.md
@@ -52,7 +52,7 @@ jobs:
           sudo gem install cocoapods
 
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lint podspec
         run: |

--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 24.x
         registry-url: https://registry.npmjs.org/

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -144,7 +144,7 @@ class OpeningHoursChecker {
         }
 
         let now = validateFor
-        var calendar = Calendar.current
+        var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = timeZone
 
         let timeFormatter = DateFormatter()
@@ -186,11 +186,12 @@ class OpeningHoursChecker {
 
         // 📅 Get day keys
         let weekday = calendar.component(.weekday, from: now) // Sunday = 1
-        let todayKey = String(weekday == 1 ? 7 : weekday - 1) // 1=Monday, ..., 7=Sunday
+        let todayInt = weekday == 1 ? 7 : weekday - 1           // ISO: Mon=1 … Sun=7
+        let todayKey = String(todayInt) // 1=Monday, ..., 7=Sunday
 
 //        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
 //        let yesterdayString = dateFormatter.string(from: yesterday)
-        let yesterdayKey = String((weekday == 2 ? 7 : weekday - 2 == 0 ? 7 : weekday - 2))
+        let yesterdayKey = String(todayInt == 1 ? 7 : todayInt - 1)   // wrap Mon → Sun
 
         // 🟨 1. Check Special for Today
         if let specialToday = openingHours.special[todayString] {

--- a/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
+++ b/Sources/WoosmapGeofencing/Business Logic/OpeningHoursChecker.swift
@@ -8,6 +8,13 @@
 
 
 import Foundation
+
+/// A store's opening hours: weekly usual periods, date-specific special periods,
+/// temporary closures, and the timezone all times are expressed in.
+///
+/// `usual` and `special` are keyed by day: usual days use ISO 8601 keys
+/// (`"1"` = Monday … `"7"` = Sunday) plus an optional `"default"` fallback,
+/// while special days are keyed by calendar date (`"yyyy-MM-dd"`).
 struct OpeningHours: Codable {
     var usual: [String: [OpeningPeriod]]
     let special: [String: [OpeningPeriod]]
@@ -18,7 +25,13 @@ struct OpeningHours: Codable {
         case usual, special, timezone
         case temporaryClosure = "temporary_closure"
     }
-    
+
+    /// Builds an ``OpeningHours`` value from a loosely-typed dictionary (e.g. a
+    /// parsed JSON payload), defaulting missing `special` / `temporary_closure`
+    /// entries to empty before decoding.
+    ///
+    /// - Parameter input: The raw `opening_hours` dictionary.
+    /// - Returns: The decoded value, or `nil` if decoding fails.
     static func openingHoursFrom(dictionary input: [String: Any]) -> OpeningHours? {
         do {
             var dictionary = input
@@ -39,6 +52,9 @@ struct OpeningHours: Codable {
     }
 }
 
+/// A single opening slot within a day. Times are `"HH:mm"` strings; a slot whose
+/// `end` is earlier than its `start` (e.g. `22:00 → 02:00`) runs overnight into
+/// the next day. `allDay == true` marks the store open for the whole day.
 struct OpeningPeriod: Codable {
     let start: String?
     let end: String?
@@ -50,21 +66,28 @@ struct OpeningPeriod: Codable {
     }
 }
 
+/// A temporary closure spanning the inclusive date range `start ... end`
+/// (`"yyyy-MM-dd"`). A single-day closure has `start == end`.
 struct ClosuerPeriod: Codable {
     let start: String
     let end: String
-   
+
     enum CodingKeys: String, CodingKey {
         case start, end
     }
 }
 
+/// A store's weekly opening schedule keyed by ISO 8601 day (`"1"`…`"7"`),
+/// decoded from a dynamic-key JSON object alongside its `timezone`.
 struct WeeklyOpening: Codable {
     let days: [String: DayOpening]
     let timezone: String
     enum CodingKeys: String, CodingKey {
         case timezone
     }
+
+    /// Decodes `timezone` and every day entry whose key is `"1"`…`"7"`,
+    /// ignoring any other keys.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         timezone = try container.decode(String.self, forKey: .timezone)
@@ -81,13 +104,19 @@ struct WeeklyOpening: Codable {
         days = tempDays
     }
 
+    /// A coding key that accepts any string, used to decode the arbitrary
+    /// day-number keys of the weekly schedule.
     struct DynamicKey: CodingKey {
         var stringValue: String
         init?(stringValue: String) { self.stringValue = stringValue }
         var intValue: Int? { return Int(stringValue) }
         init?(intValue: Int) { self.stringValue = "\(intValue)" }
     }
-    
+
+    /// Builds a ``WeeklyOpening`` from a loosely-typed dictionary (e.g. parsed JSON).
+    ///
+    /// - Parameter dictionary: The raw `weekly_opening` dictionary.
+    /// - Returns: The decoded value, or `nil` if decoding fails.
     static func weeklyOpeningFrom(dictionary: [String: Any]) -> WeeklyOpening? {
         do {
             let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
@@ -100,21 +129,42 @@ struct WeeklyOpening: Codable {
     }
 }
 
+/// The opening periods for one day of the week, and whether they represent
+/// special (date-specific) hours rather than the usual weekly schedule.
 struct DayOpening: Codable {
     let hours: [OpeningPeriod]
     let isSpecial: Bool
 }
 
 
+/// The result of an opening-hours check: whether the store is currently open and,
+/// when closed, a human-readable description of the next opening time.
 struct OpeningStatus {
     public let isOpen: Bool
     public let nextOpening: String?
 }
 
+/// Evaluates a store's ``OpeningHours`` to decide whether it is open at a given
+/// instant, accounting for special days, temporary closures, and slots that run
+/// past midnight. Stateless — all entry points are `static`.
 class OpeningHoursChecker {
-    
-    
-    
+
+    /// Determines whether a store is open at a given moment from its opening hours.
+    ///
+    /// Evaluation happens in the store's own timezone and, in order, considers:
+    /// special (date-specific) hours, temporary closures, the current day's usual
+    /// hours, and the previous day's overnight hours (slots whose end time is
+    /// earlier than their start, e.g. `22:00 → 02:00`) that spill past midnight.
+    /// Day keys are ISO 8601 (`"1"` = Monday … `"7"` = Sunday); a `"default"`
+    /// entry in `usual` is applied to any day without its own hours.
+    ///
+    /// - Parameters:
+    ///   - inputs: The store's opening hours, including timezone, usual and
+    ///     special periods, and temporary closures.
+    ///   - validateFor: The instant to evaluate. Defaults to now.
+    /// - Returns: An ``OpeningStatus`` whose `isOpen` reports the state at
+    ///   `validateFor`, and whose `nextOpening` describes the next opening time
+    ///   when closed (`nil` when open or when no upcoming time is known).
     public static func check(openingHours inputs: OpeningHours, validateFor:Date = Date()) -> OpeningStatus {
         
         func datesBetween(start: String, end: String, formatter: DateFormatter) -> [String] {
@@ -234,6 +284,17 @@ class OpeningHoursChecker {
         return OpeningStatus(isOpen: false, nextOpening: nil)
     }
 
+    /// Returns an open status if `nowTime` falls within any of the given periods.
+    ///
+    /// Handles all-day periods, normal periods (`start <= end`), and overnight
+    /// periods (`start > end`) that wrap past midnight.
+    ///
+    /// - Parameters:
+    ///   - periods: The candidate opening periods for the day.
+    ///   - nowTime: The time-of-day to test, as a `"HH:mm"` `Date`.
+    ///   - formatter: The `"HH:mm"` formatter used to parse period bounds.
+    /// - Returns: An open ``OpeningStatus`` if a matching period is found,
+    ///   otherwise `nil`.
     private static func checkPeriods(
         _ periods: [OpeningPeriod],
         nowTime: Date,

--- a/Tests/WoosmapGeofencingTests/POITests.swift
+++ b/Tests/WoosmapGeofencingTests/POITests.swift
@@ -873,4 +873,72 @@ class POIDBTest: XCTestCase {
         let result = poi.calculateOpenNow(timeStamp: weekDate) //10 AM
         XCTAssertFalse(result)
     }
+
+    /// Regression for issue #163: a Saturday slot that runs past midnight
+    /// (e.g. 22:00 → 02:00, ISO key "6") must keep the store open on Sunday
+    /// between 00:00 and 02:00. Before the fix, yesterdayKey resolved to "-1"
+    /// on Sunday, so Saturday's overnight hours were never checked.
+    func testSaturdayOvernightOpenOnSunday() throws {
+        let poi = POI()
+
+        /// Saturday (ISO "6") open 22:00 → 02:00, Sunday (ISO "7") open 10:00 → 14:00
+        let testdata = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "store_id": "18409_190784",
+                        "name": "Elphinstone Road",
+                        "opening_hours": {
+                            "usual": {
+                                "6": [
+                                    {
+                                        "start": "22:00",
+                                        "end": "02:00"
+                                    }
+                                ],
+                                "7": [
+                                    {
+                                        "start": "10:00",
+                                        "end": "14:00"
+                                    }
+                                ]
+                            },
+                            "special": {},
+                            "timezone": "Asia/Kolkata",
+                            "temporary_closure": []
+                        }
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            72.835595,
+                            19.009997
+                        ]
+                    }
+                }
+            ]
+        }
+        """
+        poi.jsonData = testdata.data(using: .utf8)!
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.timeZone = TimeZone(identifier: "Asia/Kolkata")
+
+        // Saturday night, inside today's overnight slot → open
+        XCTAssertTrue(poi.calculateOpenNow(timeStamp: formatter.date(from: "2025-08-02 23:00")!))
+
+        // Sunday early morning, still inside Saturday's overnight slot → open (the bug)
+        XCTAssertTrue(poi.calculateOpenNow(timeStamp: formatter.date(from: "2025-08-03 00:30")!))
+        XCTAssertTrue(poi.calculateOpenNow(timeStamp: formatter.date(from: "2025-08-03 01:59")!))
+
+        // Sunday after the overnight slot ends, before Sunday's own hours → closed
+        XCTAssertFalse(poi.calculateOpenNow(timeStamp: formatter.date(from: "2025-08-03 02:30")!))
+
+        // Sunday during its own usual hours → open
+        XCTAssertTrue(poi.calculateOpenNow(timeStamp: formatter.date(from: "2025-08-03 11:00")!))
+    }
 }

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,1 +1,1 @@
-- Updated:  improved main-thread handling for better reliability and performance
+- Fixed: opening hours slots that run past midnight (e.g. 22:00 → 02:00) now correctly keep a store open into the next day

--- a/WoosmapGeofencingCore.podspec
+++ b/WoosmapGeofencingCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'WoosmapGeofencingCore'
-  s.version = '4.4.0'
+  s.version = '4.4.1'
   s.license = 'BSD'
   s.summary = 'Geofencing in Swift'
   s.homepage = 'https://github.com/woosmap/geofencing-core-ios-sdk'

--- a/WoosmapGeofencingCore.xcodeproj/project.pbxproj
+++ b/WoosmapGeofencingCore.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.4.0;
+				MARKETING_VERSION = 4.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -690,7 +690,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.4.0;
+				MARKETING_VERSION = 4.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = woosmap.WoosmapGeofencing;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Issue
Fixes #39

## Describe your changes
Fixes an opening-hours bug where a slot that runs past midnight (e.g. Saturday `22:00 → 02:00`) was not honoured on the following day.

- **`OpeningHoursChecker`**
  - Switched the working calendar from `Calendar.current` to `Calendar(identifier: .iso8601)` so weekday math is consistent with the ISO day keys (`"1"` = Monday … `"7"` = Sunday).
  - Corrected `yesterdayKey` derivation: it is now derived from the ISO `todayInt`, wrapping Monday → Sunday. Previously it could resolve to an invalid key (e.g. `"-1"` on Sunday), so the prior day's overnight hours were never checked.
  - Added doc comments across the `OpeningHours`, `OpeningPeriod`, `ClosuerPeriod`, `WeeklyOpening`, `DayOpening`, `OpeningStatus` models and the `OpeningHoursChecker` entry points.

- **CI workflows**
  - Bumped `actions/checkout@v4 → v6`, `softprops/action-gh-release@v2 → v3` (deploy.yml) and `actions/setup-node@v4 → v5` (version_checker.yml).

## How to test
1. Run the test suite: `swift test` (or via Xcode).
2. Verify the new regression test `testSaturdayOvernightOpenOnSunday` in `Tests/WoosmapGeofencingTests/POITests.swift` passes. It covers a Saturday `22:00 → 02:00` overnight slot and asserts the store is:
   - open Saturday 23:00,
   - still open Sunday 00:30 and 01:59 (the previously-failing case),
   - closed Sunday 02:30 (after the overnight slot, before Sunday's own hours),
   - open Sunday 11:00 (its own usual hours).

## Checklist:
- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
N/A

### Libs/SDKs
N/A