### PR TITLE
Pin GitHub Actions to exact versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.1.0
 
       - name: Fetch SDK version from Podspec
         id: extract_version
@@ -35,7 +35,7 @@ jobs:
           git push origin ${{ steps.extract_version.outputs.sdk_version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.0.2
         with:
           tag_name: ${{ steps.extract_version.outputs.sdk_version }}
           body_path: WHATSNEW.md
@@ -52,7 +52,7 @@ jobs:
           sudo gem install cocoapods
 
       - name: Checkout default branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.1.0
 
       - name: Lint podspec
         run: |

--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v5.0.0
       with:
         node-version: 24.x
         registry-url: https://registry.npmjs.org/
 
     - name: Checkout base branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v6.1.0
       with:
         ref: ${{ github.base_ref }}
         submodules: recursive
@@ -76,7 +76,7 @@ jobs:
         rm -rf sdk
 
     - name: Checkout PR source branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v6.1.0
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         
@@ -102,7 +102,7 @@ jobs:
         exit 1
 
     - name: Refetch PR source branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v6.1.0
       with:
         ref: "${{ github.head_ref || github.ref_name }}"
         submodules: recursive
@@ -140,7 +140,7 @@ jobs:
       steps:
 
         - name: Refetch PR source branch
-          uses: actions/checkout@v6
+          uses: actions/checkout@v6.1.0
           with:
             ref: "${{ github.head_ref || github.ref_name }}"
             
@@ -153,7 +153,7 @@ jobs:
             sed -i "s/MARKETING_VERSION \= [^\;]*\;/MARKETING_VERSION = $SDK_VERSION;/" WoosmapGeofencingCore.xcodeproj/project.pbxproj
         
         - name: Commit and push changes
-          uses: devops-infra/action-commit-push@master
+          uses: devops-infra/action-commit-push@v1.5.0
           env:
             SDK_VERSION: ${{ needs.Versioning.outputs.version }}
           with:


### PR DESCRIPTION
Addresses all 6 high-severity Bastion SAST findings on this repo — all one rule, `github-actions-mutable-action-tag` (CWE-1357 / CWE-353, OWASP A08).

All nine third-party `uses:` refs now name an exact version:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v6` | `@v6.1.0` |
| `actions/setup-node` | `@v5` | `@v5.0.0` |
| `softprops/action-gh-release` | `@v3` | `@v3.0.2` |
| `devops-infra/action-commit-push` | `@master` | `@v1.5.0` |

Each was resolved from what its ref points at right now, so behaviour is unchanged.

### The one that actually mattered

`devops-infra/action-commit-push@master` was tracking a **third-party branch**, not a version — and that action *commits and pushes to this repository*. A silent repoint of that branch would have handed an outside maintainer write access to our source, via `version_checker.yml`. It's now on the `v1.5.0` release.

Semgrep wants a 40-character commit SHA; Woosmap policy is exact version tags, so these are recorded as accepted risk in Bastion rather than fixed.

## Worth noting: no Dependabot config here

Unlike the sibling `geofencing-core-android-sdk`, this repo has no `.github/dependabot.yml`, so nothing will bump these pins as new versions ship. Adding a `github-actions` entry with a 7-day cooldown would fix that. I left it out because it's additive rather than a finding fix — say the word and I'll add it.

Also note `setup-node@v5` here versus `@v6` in the sibling repo; worth aligning at some point.

## Risk and rollback

Only `uses:` refs changed — no inputs, triggers, or job logic. Both workflow files verified as parseable YAML and all four tags confirmed to resolve upstream. `deploy.yml` runs on release and `version_checker.yml` on schedule, so neither is fully exercised by this PR. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)